### PR TITLE
Add regex-based public route matching for UUID paths

### DIFF
--- a/src/main/java/com/platform/api_gateway/filters/JwtAuthenticationFilter.java
+++ b/src/main/java/com/platform/api_gateway/filters/JwtAuthenticationFilter.java
@@ -22,6 +22,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 /**
  * Reactive filter that validates JWT tokens and propagates user context headers.
@@ -37,19 +38,27 @@ public class JwtAuthenticationFilter implements WebFilter {
     private String jwtSecret;
     /** Path matcher for matching request paths. */
     private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
-    /** List of public route patterns that do not require authentication. */
+    /** Public routes that don’t require any token. */
     private static final List<String> PUBLIC_PATTERNS = List.of(
-            "/auth/**",                                           // login / register auth
-            "/users/api/v1/users/register",                       // register
-            "/users/api/v1/ngos/all-approved",                    // list approved NGOs
-            "/users/api/v1/ngos/{ngoId}",                         // NGO detail
-            "/campaigns/api/v1/campaigns/filter",                 // campaign filter
-            "/campaigns/api/v1/campaigns/{campaignId}",           // campaign detail
-            "/campaigns/api/v1/categories/all",                   // list categories
-            "/campaigns/api/v1/comments/{campaignId}",            // campaign comments
-            "/campaigns/api/v1/message-campaigns/{campaignId}"    // campaign messages
+            "/auth/**",
+            "/users/api/v1/users/register",
+            "/users/api/v1/ngos/all-approved",
+            "/campaigns/api/v1/campaigns/filter",
+            "/campaigns/api/v1/categories/all"
     );
 
+    /** Public routes that must contain a valid UUID in the path. */
+    private static final List<String> PUBLIC_REGEX_PATTERNS = List.of(
+            "/users/api/v1/ngos/",
+            "/campaigns/api/v1/campaigns/",
+            "/campaigns/api/v1/comments/",
+            "/campaigns/api/v1/message-campaigns/"
+    );
+
+    /** UUID regex (RFC4122, case-insensitive). */
+    private static final Pattern UUID_REGEX =
+            Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]"
+                    + "{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$");
     /**
      * Filters incoming requests to validate JWT tokens
      * and propagate user context headers.
@@ -67,14 +76,14 @@ public class JwtAuthenticationFilter implements WebFilter {
             return chain.filter(exchange);
         }
         // Public routes (login, register, view campaigns/NGOs)
-        if (isPublicRoute(path)) {
-            log.debug("Is public route: {}", path);
+        if (isPublicRoute(path) || isPublicRouteRegex(path)) {
+            log.info("Is public route: {}", path);
             return chain.filter(ensureRequestId(exchange));
         }
 
         // Allow internal service requests to pass through
         if (isInternalRequest(exchange)) {
-            log.debug("Is internal request: {}", path);
+            log.info("Is internal request: {}", path);
             return chain.filter(ensureRequestId(exchange));
         }
 
@@ -181,12 +190,28 @@ public class JwtAuthenticationFilter implements WebFilter {
         return Objects.nonNull(internalHeader) && !internalHeader.isBlank();
     }
 
-    /*  Checks if the request path matches any public route patterns.
+    /**
+     * Checks if the request path matches any public route patterns.
      *
      * @param path the request path
      * @return true if the path is public, false otherwise
      */
     private boolean isPublicRoute(String path) {
         return PUBLIC_PATTERNS.stream().anyMatch(pattern -> PATH_MATCHER.match(pattern, path));
+    }
+
+    /**
+     * Regex-based path match for UUID-dependent routes.
+     * @param path the request path
+     * @return true if the path matches a public regex route, false otherwise
+     */
+    private boolean isPublicRouteRegex(String path) {
+        return PUBLIC_REGEX_PATTERNS.stream().anyMatch(prefix -> {
+            if (path.startsWith(prefix)) {
+                String lastSegment = path.substring(prefix.length());
+                return UUID_REGEX.matcher(lastSegment).matches();
+            }
+            return false;
+        });
     }
 }


### PR DESCRIPTION
Introduces a new mechanism to allow certain public routes that require a valid UUID in the path by matching against regex patterns. This enhances flexibility for public endpoints such as NGO and campaign details, ensuring only valid UUIDs are accepted without requiring authentication.

# Name of Feature/Fix/Refactor
<!--- Put a name to this change -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] The test coverage is greater than 80%
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I run "mvn javadoc:javadoc" to generate the javadoc documentation

# 🔗 Merge Convention

| Branch from  | Branch to        | Merge commit | Squash and Merge |
|--------------|------------------|--------------|------------------|
| feature      | develop          | ❌           | ✅               |
| hotfix/      | master           | ❌           | ✅               |
| fix/         | release/         | ❌           | ✅               |
| release/     | master           | ✅           | ❌               |
| backport/    | develop - release| ✅           | ❌               |

---

## ❓ What happens if I do a *merge commit* when I should have done a *squash*?

- Nothing serious, we would just be bringing unnecessary commits into the branch where we are merging.  
  Example: if in my `feature/` branch I have 15 commits and the comments are not descriptive (fix, fix tests, working), I would be pushing all of those into `develop`, while with *Squash* I would only push a single one.

---

## ❓ What happens if I do a *squash* when I should have done a *merge commit*?

- In this case, we wouldn’t be fulfilling the purpose we expect, which is to bring the commits from one branch to another in order to align them.  
- For example, when we merge a `release` into `master`, the goal is to keep `develop` and `master` aligned.  
- If we use *squash* as a merge strategy, they will continue having different commits, which could cause conflicts in the next `release`.
